### PR TITLE
Fix dataset merging by symbol

### DIFF
--- a/TradingLogic/prepare_dataset.py
+++ b/TradingLogic/prepare_dataset.py
@@ -1,10 +1,12 @@
-import pandas as pd
 from datetime import datetime, timedelta
-import os
+from pathlib import Path
 
-# Répertoires où se trouvent les données 
-NEWS_PATH = "/home/saadyaq/SE/Python/finsentbot/data/raw/news_sentiment.jsonl"
-PRICES_PATH = "/home/saadyaq/SE/Python/finsentbot/data/raw/stock_prices.jsonl"
+import pandas as pd
+
+# Répertoires où se trouvent les données
+BASE_DIR = Path(__file__).resolve().parent.parent
+NEWS_PATH = BASE_DIR / "data" / "raw" / "news_sentiment.jsonl"
+PRICES_PATH = BASE_DIR / "data" / "raw" / "stock_prices.jsonl"
 
 # Fenêtre d'observation après la news
 OBSERVATION_WINDOW_MINUTES = 2
@@ -13,37 +15,33 @@ THRESHOLD = 0.005
 def load_data():
     news_df = pd.read_json(NEWS_PATH, lines=True)
     prices_df = pd.read_json(PRICES_PATH, lines=True)
-    print(prices_df[prices_df["symbol"] == "ADP"]["timestamp"].sort_values().tail(10))
-    print(news_df["timestamp"].max())
-    print(prices_df["timestamp"].max())
-    
 
     # Convertir en datetime
     news_df["timestamp"] = pd.to_datetime(news_df["timestamp"]).dt.tz_localize(None)
     prices_df["timestamp"] = pd.to_datetime(prices_df["timestamp"]).dt.tz_localize(None)
-    # Trier pour merge_asof
-    news_df = news_df.sort_values("timestamp")
-    prices_df = prices_df.sort_values("timestamp")
-    print("Avant Merge:", len(news_df), len(prices_df))
+
+    # Supprimer les news sans symbole pour éviter les associations aléatoires
+    news_df = news_df.dropna(subset=["symbol"])
+
+    # Trier pour merge_asof (timestamp global puis symbole)
+    news_df = news_df.sort_values(["timestamp", "symbol"])
+    prices_df = prices_df.sort_values(["timestamp", "symbol"])
+
     # Associer symbol et prix au moment de la news (merge asof)
     enriched_news = pd.merge_asof(
         news_df,
         prices_df[["timestamp", "symbol", "price"]],
         on="timestamp",
+        by="symbol",
         direction="backward",
         tolerance=pd.Timedelta("10min")  # ← marge de tolérance temporelle
     )
-    print("Colonnes présentes :", enriched_news.columns)
-    # Choisir l'une des deux colonnes symbol (selon celle qui est correcte)
-    enriched_news["symbol"] = enriched_news["symbol_x"].combine_first(enriched_news["symbol_y"])
 
     if "symbol" not in enriched_news.columns or "price" not in enriched_news.columns:
         raise ValueError("⛔ Les colonnes 'symbol' ou 'price' sont absentes du fichier news.")
-    
-    news_df = enriched_news.dropna(subset=["symbol", "price"])
+
     # Supprimer les news sans correspondance de prix
     news_df = enriched_news.dropna(subset=["symbol", "price"])
-    print("apres merge", len(news_df),len(prices_df))
     return news_df, prices_df
 
 def generate_labels(news_df, prices_df):
@@ -101,6 +99,7 @@ if __name__ == "__main__":
     news_df, prices_df = load_data()
     train_dataset = generate_labels(news_df, prices_df)
 
-    os.makedirs("home/saadyaq/SE/finsentbot/data/training_datasets", exist_ok=True)
-    train_dataset.to_csv("home/saadyaq/SE/finsentbot/data/training_datasets/train.csv", index=False)
+    output_dir = BASE_DIR / "data" / "training_datasets"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    train_dataset.to_csv(output_dir / "train.csv", index=False)
     print("✅ Dataset generated with", len(train_dataset), "samples.")


### PR DESCRIPTION
## Summary
- ensure dataset generation uses paths relative to the repository
- drop news without tickers and align prices by symbol to avoid incorrect assignments

## Testing
- `python TradingLogic/prepare_dataset.py`
- `pytest` *(fails: kafka.errors.NoBrokersAvailable)*

------
https://chatgpt.com/codex/tasks/task_e_6895f88df2fc832e8b4613b660916024